### PR TITLE
Add helper classes for accessibility and invisible, focusable skip link.

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,5 +1,6 @@
 <aside>
   <p class="intro">{{ site.subtitle }}</p>
+  <a class="skip-link visuallyhidden focusable" href="#main">Skip to Main Content</a>
   <nav>
     <ul>
       {% for link in site.navigation %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
 
         {% include sidebar.html %}
 
-        <section class="main-content" role="main">
+        <section id="main" class="main-content" role="main">
           {{ content }}
         </section>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -142,6 +142,21 @@ a.title-link:focus {
     border-bottom: none;
 }
 
+a.skip-link {
+    color: #0072ce;
+    border-bottom: none;
+    padding: .25em;
+}
+
+a.skip-link:hover,
+a.skip-link:active,
+a.skip-link:focus {
+    background-color: #0072ce;
+    color: #fff;
+    border-bottom: none;
+}
+
+
 /*
 Navigation
 ==================================
@@ -205,6 +220,47 @@ header {
 
 .content {
     margin-top: 80px;
+}
+
+
+/*
+Helpers
+==================================
+*/
+
+/* Hide from both screenreaders and browsers: h5bp.com/u */
+.hidden {
+    display: none !important;
+    visibility: hidden;
+}
+
+/* Hide only visually, but have it available for screenreaders: h5bp.com/v */
+.visuallyhidden {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}
+
+/* Extends the .visuallyhidden class to allow the element to be focusable
+ * when navigated to via the keyboard: h5bp.com/p */
+.visuallyhidden.focusable:active,
+.visuallyhidden.focusable:focus {
+    clip: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    position: static;
+    width: auto;
+}
+
+/* Hide visually and from screenreaders, but maintain layout */
+.invisible {
+    visibility: hidden;
 }
 
 


### PR DESCRIPTION
This pull request adds some class names for accessibility usefulness and makes an invisible skip link that becomes visible when keyboard users tab to it. This helps make the skip link usable for not just screen reader users, but keyboard users as well.

**Unfocused**
![unfocused-skip-link](https://f.cloud.github.com/assets/1473618/1601909/283e9216-5390-11e3-82a9-bd954d14f51d.png)

**Focused**
![focused-skip-link](https://f.cloud.github.com/assets/1473618/1601915/389227f4-5390-11e3-9394-5eafbcf14c8c.png)
