### PR TITLE
switching from redcarpet to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Base configuration
 permalink: /:title
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-markdown: redcarpet
+markdown: kramdown
 pygments: true
 
 # Title


### PR DESCRIPTION
Kramdown is a more fully-featured markdown implementation, so switching to it for DOCter. (I know it supports footnotes but redcarpet does not. I believe there are other features too.)
