### PR TITLE
update pygments config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 permalink: /:title
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
 markdown: kramdown
-pygments: true
+highlighter: pygments
 
 # Title
 name: DOCter


### PR DESCRIPTION
![screen shot 2015-08-27 at 10 30 52 am](https://cloud.githubusercontent.com/assets/702526/9523283/398b60c8-4ca7-11e5-909b-625f201231a7.png)
When serving the site locally you get a warning about the pygments config option being updated, so this fixes it.
## Changes
- change `pygments` to `highlighter`
- set `highlighter` to `pygments`
## Testing
- check out locally
- serve locally with `jekyll serve --baseurl ''`
## Review
- @ascott1
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Visually tested in supported browsers and devices 
