### PR TITLE
default to site.name for page titles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,13 @@
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
-    <title>{{ page.title }}</title>
+    <title>
+      {% if page.title == null %}
+        {{ site.name }}
+      {% else %}
+        {{ page.title }} - {{ site.name }}
+      {% endif %}
+    </title>
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/normalize.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: DOCter
 ---
 
 {% capture index %}{% include index.md %}{% endcapture %}


### PR DESCRIPTION
When I first set up a project to use DOCter, I was a little puzzled and annoyed that the page title was still DOCter after I updated my config file. This defaults the page titles to the `site.name` variable for faster setup.
## Additions
- add check for `page.title` in default layout
- use `site.name` as title if there is no page title defined
- also use `site.name` when `page.title` _is_ defined like so "Page Title - SiteName"
## Removals
- remove `title` from index page front matter so it defaults to the site name from site config
## Testing
- check out locally
- run `jekyll serve --baseurl ''`
- observe page titles on index page and the example page to see the change
- edit `site.name` to see the index page title change dynamically (I think you have to restart the serve task though)
## Review
- @ascott1 
## Screenshots
### index page title

![screen shot 2015-08-27 at 11 26 28 am](https://cloud.githubusercontent.com/assets/702526/9524846/203f2ce6-4caf-11e5-8a71-e3ffa5999040.png)
### example page title with site.name in it

![screen shot 2015-08-27 at 11 26 25 am](https://cloud.githubusercontent.com/assets/702526/9524863/30437106-4caf-11e5-92a0-5610ab2359ba.png)
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Visually tested in supported browsers and devices 
