### PR TITLE
Fixes #32.

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -171,8 +171,8 @@ Navigation
 .sidebar-nav a {
   display: block;
   padding: 10px;
-  -webkit-transition: .4s;
-  transition: .4s;
+  -webkit-transition: unset;
+  transition: unset;
 }
 .sidebar-nav a,
 .sidebar-nav a:link,
@@ -188,7 +188,19 @@ Navigation
   border-left: 4px solid {{ site.brand_color }};
   background-color: transparent;
   border-bottom: 1px solid #babbbd;
+}
+.sidebar-nav li:hover,
+.sidebar-nav li:active,
+.sidebar-nav .sidebar-nav-active {
   padding-left: 0;
+}
+.sidebar-nav a:focus {
+  padding-left: 6px;
+}
+.sidebar-nav li:hover a:focus,
+.sidebar-nav li:active a:focus {
+  border-left: none;
+  padding-left: 10px;
 }
 .sidebar-nav ul {
   margin: 0;


### PR DESCRIPTION
Fixes #32.

Remove transition animation on links in the sidebar, and adjust their border and padding appropriately with regards to the state of the li containing them.
