### PR TITLE
Add basic offline support with a service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ in `_config.yml`: set `offline_cache` to false (defaults to true).
 
 in `_config.yml` change the value of `cache_name`
 
-**To add additional pages or files to the cache:**
+**To add additional files to the cache:**
 
 Update the `filesToCache` array in `sw.js`;
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bundle exec jekyll serve --watch --baseurl ''
 Open it up in your browser: <http://localhost:4000/>
 
 
-## _config.yml
+## `_config.yml`
 
 Options within the `_config.yml` file allow you to control the site's title, subtitle, logo, author information, and the left column navigation.
 
@@ -47,6 +47,24 @@ Sometimes it's nice to preview your Jekyll site before you push your `gh-pages` 
 4. Finally, if you'd like to preview your site before committing/deploying using `jekyll serve`, be sure to pass an **empty string** to the `--baseurl` option, so that you can view everything at `localhost:4000` normally (without `/project-name` at the beginning): `jekyll serve --baseurl ''`
 
 This way, you can preview your site locally from the site root on localhost, but when GitHub generates your pages from the gh-pages branch all the URLs will start with `/project-name` and resolve properly.
+
+## Offline support
+
+By default DOCter provides offline support via a [Service Worker](http://www.html5rocks.com/en/tutorials/service-worker/introduction/). This means that after an initial load of your DOCter site, a cached version will be available offline in some modern browsers.
+
+**To disable offline caching:**
+
+in `_config.yml`: set `offline_cache` to false (defaults to true).
+
+**To update the cached version of your site:**
+
+in `_config.yml` change the value of `cache_name`
+
+**To add additional pages or files to the cache:**
+
+Update the `filesToCache` array in `sw.js`;
+
+
 
 ## License
 

--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ navigation:
   url: ./
   internal: true
 - text: Example Page
-  url: site.baseurl
+  url: example_page/
   internal: true
 - text: DOCter Repo
   url: https://github.com/cfpb/DOCter

--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ navigation:
   url: ./
   internal: true
 - text: Example Page
-  url: example_page
+  url: example_page/
   internal: true
 - text: DOCter Repo
   url: https://github.com/cfpb/DOCter

--- a/_config.yml
+++ b/_config.yml
@@ -50,3 +50,7 @@ repos:
 
 # Style Variables
 brand_color: "#2cb34a"
+
+# Offline caching
+offline_cache: true
+cache_name: DOCter-v1

--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ navigation:
   url: ./
   internal: true
 - text: Example Page
-  url: example_page/
+  url: site.baseurl
   internal: true
 - text: DOCter Repo
   url: https://github.com/cfpb/DOCter

--- a/_config.yml
+++ b/_config.yml
@@ -53,4 +53,4 @@ brand_color: "#2cb34a"
 
 # Offline caching
 offline_cache: true
-cache_name: DOCter-v1
+cache_name: DOCter-v1.1

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,12 +49,14 @@
         </div><!--/.wrap -->
       </footer>
     </div> <!-- /.container -->
-    <script>
-      if('serviceWorker' in navigator) {
-        navigator.serviceWorker
-         .register('/sw.js')
-         .then(function() { console.log('Service Worker Registered'); });
-       }
-    </script>
+    {% if site.offline_cache == true %}
+      <script>
+        if('serviceWorker' in navigator) {
+          navigator.serviceWorker
+           .register('/sw.js')
+           .then(function() { console.log('Service Worker Registered'); });
+         }
+      </script>
+    {% endif %}
     </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,10 +51,12 @@
     </div> <!-- /.container -->
     {% if site.offline_cache == true %}
       <script>
-        if('serviceWorker' in navigator) {
+        if( 'serviceWorker' in navigator ) {
           navigator.serviceWorker
-           .register('{{ site.baseurl }}/sw.js')
-           .catch(function() {});
+           .register( '{{ site.baseurl }}/sw.js' )
+           .catch(function( err ) {
+             console.log( 'ServiceWorker registration failed: ', err );
+           });
          }
       </script>
     {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,5 +49,12 @@
         </div><!--/.wrap -->
       </footer>
     </div> <!-- /.container -->
+    <script>
+      if('serviceWorker' in navigator) {
+        navigator.serviceWorker
+         .register('/sw.js')
+         .then(function() { console.log('Service Worker Registered'); });
+       }
+    </script>
     </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,7 @@
       <script>
         if('serviceWorker' in navigator) {
           navigator.serviceWorker
-           .register('/sw.js')
+           .register('{{ site.baseurl }}/sw.js')
            .then(function() { console.log('Service Worker Registered'); });
          }
       </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -54,7 +54,7 @@
         if('serviceWorker' in navigator) {
           navigator.serviceWorker
            .register('{{ site.baseurl }}/sw.js')
-           .then(function() { console.log('Service Worker Registered'); });
+           .catch(function() {});
          }
       </script>
     {% endif %}

--- a/cache-polyfill.js
+++ b/cache-polyfill.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+if (!Cache.prototype.addAll) {
+  Cache.prototype.addAll = function addAll(requests) {
+    var cache = this;
+
+    // Since DOMExceptions are not constructable:
+    function NetworkError(message) {
+      this.name = 'NetworkError';
+      this.code = 19;
+      this.message = message;
+    }
+    NetworkError.prototype = Object.create(Error.prototype);
+
+    return Promise.resolve().then(function() {
+      if (arguments.length < 1) throw new TypeError();
+
+      // Simulate sequence<(Request or USVString)> binding:
+      var sequence = [];
+
+      requests = requests.map(function(request) {
+        if (request instanceof Request) {
+          return request;
+        }
+        else {
+          return String(request); // may throw TypeError
+        }
+      });
+
+      return Promise.all(
+        requests.map(function(request) {
+          if (typeof request === 'string') {
+            request = new Request(request);
+          }
+
+          var scheme = new URL(request.url).protocol;
+
+          if (scheme !== 'http:' && scheme !== 'https:') {
+            throw new NetworkError("Invalid scheme");
+          }
+
+          return fetch(request.clone());
+        })
+      );
+    }).then(function(responses) {
+      // TODO: check that requests don't overwrite one another
+      // (don't think this is possible to polyfill due to opaque responses)
+      return Promise.all(
+        responses.map(function(response, i) {
+          return cache.put(requests[i], response);
+        })
+      );
+    }).then(function() {
+      return undefined;
+    });
+  };
+}

--- a/index.html
+++ b/index.html
@@ -33,4 +33,5 @@ layout: default
         <span class="post-date">{{ post.date | date_to_string }}</span>
       </li>
     {% endfor %}
+  </ul>
 </div>

--- a/index.html
+++ b/index.html
@@ -33,5 +33,4 @@ layout: default
         <span class="post-date">{{ post.date | date_to_string }}</span>
       </li>
     {% endfor %}
-  </ul>
 </div>

--- a/sw.js
+++ b/sw.js
@@ -6,18 +6,18 @@ importScripts( '/cache-polyfill.js' );
 
 var filesToCache = [
   // root
-  '/',
-  '/index.html',
+  '{{ site.baseurl }}/',
+  '{{ site.baseurl }}/index.html',
   // css
-  '/assets/css/main.css',
-  '/assets/css/normalize.css',
-  '/assets/css/syntax.css',
+  '{{ site.baseurl }}/assets/css/main.css',
+  '{{ site.baseurl }}/assets/css/normalize.css',
+  '{{ site.baseurl }}/assets/css/syntax.css',
   // images
-  '/assets/img/octocat.png',
+  '{{ site.baseurl }}/assets/img/octocat.png',
   // pages
-  '/example_page/',
+  '{{ site.baseurl }}/example_page/',
   // posts
-  {% for post in site.posts %}'{{ post.url }}',{% endfor %}
+  {% for post in site.posts %}'{{ site.baseurl }}{{ post.url }}',{% endfor %}
 ];
 
 self.addEventListener( 'install', function( e ) {

--- a/sw.js
+++ b/sw.js
@@ -15,7 +15,7 @@ var filesToCache = [
   // images
   '{{ site.baseurl }}/assets/img/octocat.png',
   // pages
-  '{{ site.baseurl }}/example_page',
+  '{{ site.baseurl }}/example_page/',
   // posts
   {% for post in site.posts %}'{{ site.baseurl }}{{ post.url }}',{% endfor %}
 ];

--- a/sw.js
+++ b/sw.js
@@ -15,7 +15,7 @@ var filesToCache = [
   // images
   '{{ site.baseurl }}/assets/img/octocat.png',
   // pages
-  '{{ site.baseurl }}/example_page/',
+  '{{ site.baseurl }}/example_page',
   // posts
   {% for post in site.posts %}'{{ site.baseurl }}{{ post.url }}',{% endfor %}
 ];

--- a/sw.js
+++ b/sw.js
@@ -2,11 +2,11 @@
 layout: null
 ---
 
-importScripts( '{{ site.baseurl }}cache-polyfill.js' );
+importScripts( '{{ site.baseurl }}/cache-polyfill.js' );
 
 var filesToCache = [
   // root
-  '{{ site.baseurl }}',
+  '{{ site.baseurl }}/',
   '{{ site.baseurl }}/index.html',
   // css
   '{{ site.baseurl }}/assets/css/main.css',

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,36 @@
+---
+layout: null
+---
+
+importScripts('/cache-polyfill.js');
+
+self.addEventListener('install', function(e) {
+  e.waitUntil(
+    caches.open('DOCter').then(function(cache) {
+      return cache.addAll([
+        // root
+        '/',
+        '/index.html',
+        // css
+        '/assets/css/main.css',
+        '/assets/css/normalize.css',
+        '/assets/css/syntax.css',
+        // images
+        '/assets/img/octocat.png',
+        // pages
+        '/example_page/',
+        // posts
+        {% for post in site.posts %}'{{ post.url }}',{% endfor %}
+      ]);
+    })
+  );
+});
+
+self.addEventListener('fetch', function(event) {
+  console.log(event.request.url);
+  event.respondWith(
+    caches.match(event.request).then(function(response) {
+      return response || fetch(event.request);
+    })
+ );
+});

--- a/sw.js
+++ b/sw.js
@@ -2,11 +2,11 @@
 layout: null
 ---
 
-importScripts( '/cache-polyfill.js' );
+importScripts( '{{ site.baseurl }}cache-polyfill.js' );
 
 var filesToCache = [
   // root
-  '{{ site.baseurl }}/',
+  '{{ site.baseurl }}',
   '{{ site.baseurl }}/index.html',
   // css
   '{{ site.baseurl }}/assets/css/main.css',

--- a/sw.js
+++ b/sw.js
@@ -15,7 +15,7 @@ var filesToCache = [
   // images
   '{{ site.baseurl }}/assets/img/octocat.png',
   // pages
-  '{{ site.baseurl }}/example_page/',
+  {% for page in site.documents %}'{{ site.baseurl }}{{ page.url }}',{% endfor %}
   // posts
   {% for post in site.posts %}'{{ site.baseurl }}{{ post.url }}',{% endfor %}
 ];

--- a/sw.js
+++ b/sw.js
@@ -4,24 +4,26 @@ layout: null
 
 importScripts('/cache-polyfill.js');
 
+var filesToCache = [
+  // root
+  '/',
+  '/index.html',
+  // css
+  '/assets/css/main.css',
+  '/assets/css/normalize.css',
+  '/assets/css/syntax.css',
+  // images
+  '/assets/img/octocat.png',
+  // pages
+  '/example_page/',
+  // posts
+  {% for post in site.posts %}'{{ post.url }}',{% endfor %}
+];
+
 self.addEventListener('install', function(e) {
   e.waitUntil(
-    caches.open('DOCter').then(function(cache) {
-      return cache.addAll([
-        // root
-        '/',
-        '/index.html',
-        // css
-        '/assets/css/main.css',
-        '/assets/css/normalize.css',
-        '/assets/css/syntax.css',
-        // images
-        '/assets/img/octocat.png',
-        // pages
-        '/example_page/',
-        // posts
-        {% for post in site.posts %}'{{ post.url }}',{% endfor %}
-      ]);
+    caches.open('{{ site.cache_name }}').then(function(cache) {
+      return cache.addAll(filesToCache);
     })
   );
 });

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
 layout: null
 ---
 
-importScripts('/cache-polyfill.js');
+importScripts( '/cache-polyfill.js' );
 
 var filesToCache = [
   // root
@@ -20,19 +20,19 @@ var filesToCache = [
   {% for post in site.posts %}'{{ post.url }}',{% endfor %}
 ];
 
-self.addEventListener('install', function(e) {
+self.addEventListener( 'install', function( e ) {
   e.waitUntil(
-    caches.open('{{ site.cache_name }}').then(function(cache) {
-      return cache.addAll(filesToCache);
+    caches.open( '{{ site.cache_name }}' )
+      .then( function( cache ) {
+        return cache.addAll( filesToCache );
     })
   );
 });
 
-self.addEventListener('fetch', function(event) {
-  console.log(event.request.url);
+self.addEventListener( 'fetch', function( event ) {
   event.respondWith(
-    caches.match(event.request).then(function(response) {
-      return response || fetch(event.request);
+    caches.match( event.request ).then( function( response ) {
+      return response || fetch( event.request );
     })
  );
 });


### PR DESCRIPTION
This adds a little service worker to enable offline support for DOCter sites. This means that DOCter sites will work without an internet connection after the initial visit. It also means that the site is _fasssssst_ after that initial page load.

Since everyone may not want to enable this feature, it can be turned off via the `_config.yml` file. It may be worth disabling this by default so no one can be bitten by lingering cache.
## Review

To review, either:
- visit my fork https://ascott1.github.io/DOCter/, give it a few seconds to make sure everything caches, disable wifi, and reload the page. :boom: you can still navigate around.
- clone my fork locally, run the jekyll server, visit the page, stop the jekyll server, visit the page again :rocket: 

@cfpb/front-end-team-admin 
