### PR TITLE
Default offline setting to false

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,5 +52,5 @@ repos:
 brand_color: "#2cb34a"
 
 # Offline caching
-offline_cache: true
+offline_cache: false
 cache_name: DOCter-v1.1


### PR DESCRIPTION
This sets the default offline setting to `false`, so that a user has to deliberately enable the service worker in the `_config.yml` file.
